### PR TITLE
SysUITuner:Re-orginazed Tuner fragmets and disable tuner activity

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -236,7 +236,7 @@
         </activity>
 
         <activity android:name=".tuner.TunerActivity"
-                  android:enabled="true"
+                  android:enabled="false"
                   android:icon="@drawable/tuner"
                   android:theme="@android:style/Theme.Material.Settings"
                   android:label="@string/status_bar_tuner"

--- a/packages/SystemUI/res/layout/status_bar_expanded_header.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded_header.xml
@@ -71,7 +71,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingStart="36dp"
-            android:layout_marginStart="8dp"
             android:tint="@color/tuner_icon_tint"
             android:tintMode="src_in"
             android:visibility="invisible"
@@ -79,13 +78,13 @@
 
     </com.android.systemui.statusbar.AlphaOptimizedFrameLayout>
 
-    <com.android.keyguard.AlphaOptimizedImageButton android:id="@+id/task_manager_button"
+    <ImageButton android:id="@+id/task_manager_button"
         style="@android:style/Widget.Material.Button.Borderless"
         android:layout_toStartOf="@id/settings_button_container"
         android:layout_width="48dp"
-        android:layout_marginStart="8dp"
         android:layout_height="@dimen/status_bar_header_height"
         android:background="@drawable/ripple_drawable"
+        android:layout_marginStart="8dp"
         android:src="@drawable/ic_tasklist_switch_normal"
         android:visibility="gone"/>
 
@@ -96,7 +95,7 @@
         android:layout_alignWithParentIfMissing="true"
         android:layout_marginStart="16dp"
         android:background="@drawable/ripple_drawable"
-        android:paddingEnd="8dp" >
+        android:paddingEnd="4dp" >
         <FrameLayout android:id="@+id/system_icons_container"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/status_bar_height"

--- a/packages/SystemUI/res/xml/tuner_prefs.xml
+++ b/packages/SystemUI/res/xml/tuner_prefs.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2015 The Android Open Source Project
-     Copyright (C) 2015 The Resurrection Remix Project
-
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-
           http://www.apache.org/licenses/LICENSE-2.0
-
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,65 +12,18 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/status_bar_tuner">
+    android:title="@string/system_ui_tuner">
 
-        <PreferenceCategory
-            android:key="hide_statusbar_items"
-            android:title="@string/statusbar_tuner_category_title">
+    <Preference
+        android:key="statusbar_icon_blacklist"
+        android:title="@string/status_bar" />
 
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="cast"
-            android:title="@string/quick_settings_cast_title" />
+    <Preference
+        android:key="demo_mode"
+        android:title="@string/demo_mode" />
 
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="hotspot"
-            android:title="@string/quick_settings_hotspot_label" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="bluetooth"
-            android:title="@string/quick_settings_bluetooth_label" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="zen"
-            android:title="@string/quick_settings_dnd_label" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="alarm_clock"
-            android:title="@string/status_bar_alarm" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="managed_profile"
-            android:title="@string/status_bar_work" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="wifi"
-            android:title="@string/quick_settings_wifi_label" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="ethernet"
-            android:title="@string/status_bar_ethernet" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="mobile"
-            android:title="@string/quick_settings_cellular_detail_title" />
-
-        <com.android.systemui.tuner.StatusBarSwitch
-            android:key="airplane"
-            android:title="@string/status_bar_airplane" />
-
-       <com.android.systemui.tuner.StatusBarSwitch
-            android:key="headset"
-            android:title="@string/status_bar_headset" />
-
-   	<com.android.systemui.tuner.StatusBarSwitch
-            android:key="volume"
-            android:title="@string/status_bar_volume" />
-
-      <com.android.systemui.tuner.StatusBarSwitch
-            android:key="vpn"
-            android:title="@string/status_bar_vpn" />
-
-        </PreferenceCategory>
+    <Preference
+        android:summary="@string/tuner_persistent_warning"
+        android:selectable="false" />
 
 </PreferenceScreen>
-

--- a/packages/SystemUI/res/xml/tuner_statusbar_icons.xml
+++ b/packages/SystemUI/res/xml/tuner_statusbar_icons.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The CyanogenMod Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  android:title="@string/status_bar">
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="cast"
+            android:title="@string/quick_settings_cast_title"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="hotspot"
+            android:title="@string/quick_settings_hotspot_label"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="bluetooth"
+            android:title="@string/quick_settings_bluetooth_label"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="zen"
+            android:title="@string/quick_settings_dnd_label"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="alarm_clock"
+            android:title="@string/status_bar_alarm"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="managed_profile"
+            android:title="@string/status_bar_work"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="wifi"
+            android:title="@string/quick_settings_wifi_label"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="ethernet"
+            android:title="@string/status_bar_ethernet"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="mobile"
+            android:title="@string/quick_settings_cellular_detail_title"/>
+
+    <com.android.systemui.tuner.StatusBarSwitch
+            android:key="airplane"
+            android:title="@string/status_bar_airplane"/>
+
+</PreferenceScreen>

--- a/packages/SystemUI/src/com/android/systemui/tuner/QsTuner.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/QsTuner.java
@@ -308,7 +308,6 @@ public class QsTuner extends Fragment implements Callback {
             else if (mSpec.equals("cast")) return R.drawable.ic_qs_cast_on;
             else if (mSpec.equals("hotspot")) return R.drawable.ic_hotspot_enable;
             else if (mSpec.equals("adb_network")) return R.drawable.ic_qs_network_adb_on;
-            else if (mSpec.equals("headsup")) return R.drawable.ic_qs_heads_up_on;
             return R.drawable.android;
         }
 

--- a/packages/SystemUI/src/com/android/systemui/tuner/StatusBarIconBlacklistFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/StatusBarIconBlacklistFragment.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.systemui.tuner;
+
+import android.annotation.Nullable;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+
+import android.preference.PreferenceGroup;
+import com.android.systemui.R;
+import com.android.systemui.statusbar.phone.StatusBarIconController;
+
+public class StatusBarIconBlacklistFragment extends PreferenceFragment {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.tuner_statusbar_icons);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        registerPrefs(getPreferenceScreen());
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        unregisterPrefs(getPreferenceScreen());
+    }
+
+    private void registerPrefs(PreferenceGroup group) {
+        TunerService tunerService = TunerService.get(getContext());
+        final int N = group.getPreferenceCount();
+        for (int i = 0; i < N; i++) {
+            Preference pref = group.getPreference(i);
+            if (pref instanceof StatusBarSwitch) {
+                tunerService.addTunable((TunerService.Tunable) pref, StatusBarIconController.ICON_BLACKLIST);
+            } else if (pref instanceof PreferenceGroup) {
+                registerPrefs((PreferenceGroup) pref);
+            }
+        }
+    }
+
+    private void unregisterPrefs(PreferenceGroup group) {
+        TunerService tunerService = TunerService.get(getContext());
+        final int N = group.getPreferenceCount();
+        for (int i = 0; i < N; i++) {
+            Preference pref = group.getPreference(i);
+            if (pref instanceof TunerService.Tunable) {
+                tunerService.removeTunable((TunerService.Tunable) pref);
+            } else if (pref instanceof PreferenceGroup) {
+                registerPrefs((PreferenceGroup) pref);
+            }
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerActivity.java
@@ -16,7 +16,9 @@
 package com.android.systemui.tuner;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.os.Bundle;
+import android.view.MenuItem;
 
 public class TunerActivity extends Activity {
 
@@ -27,4 +29,43 @@ public class TunerActivity extends Activity {
                 .commit();
     }
 
+    /**
+     * Base class for direct entry points into
+     * tuner fragments
+     */
+    private static abstract class FragmentTunerActivityBase extends Activity {
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            getActionBar().setDisplayHomeAsUpEnabled(true);
+            getFragmentManager().beginTransaction().replace(android.R.id.content,
+                    getFragment()).commit();
+        }
+
+        protected abstract Fragment getFragment();
+
+        @Override
+        public final boolean onOptionsItemSelected(MenuItem item) {
+            switch (item.getItemId()) {
+                case android.R.id.home:
+                    finish();
+                    return true;
+            }
+            return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static final class DemoModeActivity extends FragmentTunerActivityBase {
+        @Override
+        protected Fragment getFragment() {
+            return new DemoModeFragment();
+        }
+    }
+
+    public static final class StatusBarIconActivity extends FragmentTunerActivityBase {
+        @Override
+        protected Fragment getFragment() {
+            return new StatusBarIconBlacklistFragment();
+        }
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerFragment.java
@@ -15,8 +15,10 @@
  */
 package com.android.systemui.tuner;
 
+import android.app.AlertDialog;
 import android.app.FragmentTransaction;
-import android.content.ContentResolver;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnClickListener;
 import android.database.ContentObserver;
 import android.net.Uri;
 import android.os.Bundle;
@@ -26,7 +28,6 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
-import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.provider.Settings;
 import android.provider.Settings.System;
@@ -41,22 +42,62 @@ import com.android.systemui.tuner.TunerService.Tunable;
 
 public class TunerFragment extends PreferenceFragment {
 
-    public static final String TAG = "TunerFragment";
+    private static final String TAG = "TunerFragment";
 
-    private final SettingObserver mSettingObserver = new SettingObserver();
+    private static final String KEY_STATUSBAR_BLACKLIST = "statusbar_icon_blacklist";
+    private static final String KEY_DEMO_MODE = "demo_mode";
+
+    public static final String SETTING_SEEN_TUNER_WARNING = "seen_tuner_warning";
+
+    private static final int MENU_REMOVE = Menu.FIRST + 1;
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.tuner_prefs);
-
         getActivity().getActionBar().setDisplayHomeAsUpEnabled(true);
         setHasOptionsMenu(true);
+
+        findPreference(KEY_STATUSBAR_BLACKLIST).setOnPreferenceClickListener(new OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                FragmentTransaction ft = getFragmentManager().beginTransaction();
+                ft.replace(android.R.id.content, new StatusBarIconBlacklistFragment(),
+                        "StatusBarBlacklist");
+                ft.addToBackStack(null);
+                ft.commit();
+                return true;
+            }
+        });
+        findPreference(KEY_DEMO_MODE).setOnPreferenceClickListener(new OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                FragmentTransaction ft = getFragmentManager().beginTransaction();
+                ft.replace(android.R.id.content, new DemoModeFragment(), "DemoMode");
+                ft.addToBackStack(null);
+                ft.commit();
+                return true;
+            }
+        });
+        if (Settings.Secure.getInt(getContext().getContentResolver(), SETTING_SEEN_TUNER_WARNING,
+                0) == 0) {
+            new AlertDialog.Builder(getContext())
+                    .setTitle(R.string.tuner_warning_title)
+                    .setMessage(R.string.tuner_warning)
+                    .setPositiveButton(R.string.got_it, new OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            Settings.Secure.putInt(getContext().getContentResolver(),
+                                    SETTING_SEEN_TUNER_WARNING, 1);
+                        }
+                    }).show();
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
+
         registerPrefs(getPreferenceScreen());
         MetricsLogger.visibility(getContext(), MetricsLogger.TUNER, true);
     }
@@ -64,7 +105,6 @@ public class TunerFragment extends PreferenceFragment {
     @Override
     public void onPause() {
         super.onPause();
-        getContext().getContentResolver().unregisterContentObserver(mSettingObserver);
 
         unregisterPrefs(getPreferenceScreen());
         MetricsLogger.visibility(getContext(), MetricsLogger.TUNER, false);
@@ -97,23 +137,25 @@ public class TunerFragment extends PreferenceFragment {
     }
 
     @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.add(Menu.NONE, MENU_REMOVE, Menu.NONE, R.string.remove_from_settings);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 getActivity().finish();
                 return true;
+            case MENU_REMOVE:
+                TunerService.showResetRequest(getContext(), new Runnable() {
+                    @Override
+                    public void run() {
+                        getActivity().finish();
+                    }
+                });
+                return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private final class SettingObserver extends ContentObserver {
-        public SettingObserver() {
-            super(new Handler());
-        }
-
-        @Override
-        public void onChange(boolean selfChange, Uri uri, int userId) {
-            super.onChange(selfChange, uri, userId);
-        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerService.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerService.java
@@ -212,6 +212,10 @@ public class TunerService extends SystemUI {
                 // Tell the tuner (in main SysUI process) to clear all its settings.
                 context.sendBroadcast(new Intent(TunerService.ACTION_CLEAR));
                 // Disable access to tuner.
+                TunerService.setTunerEnabled(context, false);
+                // Make them sit through the warning dialog again.
+                Settings.Secure.putInt(context.getContentResolver(),
+                        TunerFragment.SETTING_SEEN_TUNER_WARNING, 0);
                 if (onDisabled != null) {
                     onDisabled.run();
                 }


### PR DESCRIPTION
-Improve header layout

log error :
...
01-01 07:56:56.007: W/Settings(5415): Found com.android.systemui.tuner.TunerActivity for action com.android.settings.action.EXTRA_SETTINGS missing metadata
01-01 07:57:54.846: W/OpenGLRenderer(1873): Incorrectly called buildLayer on View: FrameLayout, destroying layer...
01-01 07:57:54.846: W/OpenGLRenderer(1873): Incorrectly called buildLayer on View: FrameLayout, destroying layer...